### PR TITLE
feature: wait for server ready.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,8 +85,11 @@ Custom settings for server
   import pytest
   import requests
 
+  # Param `port`: The flask server will run on port 8000. Default is 5000.
+  # Param `server_ready_timeout`: The program will be hung up util the server is ready. 
+  #                               The max wait time is 5 seconds. Default is 3 seconds.
   @pytest.mark.server(url='/v1/books/', response={})
-  @pytest.mark.server_settings(port=8000)
+  @pytest.mark.server_settings(port=8000, server_ready_timeout=5)
   def test_handler_responses():
       response = requests.get('http://localhost:8000/v1/books/')
       assert response.status_code == 200

--- a/pytest_mock_server.py
+++ b/pytest_mock_server.py
@@ -58,6 +58,7 @@ def assert_server_ready(url, **settings) -> None:
 
     :param url: server url returned by `url_for`
     :param port: server port, default is 5000
+    :param server_ready_timeout: timeout for server to be ready, default is 3 seconds
     """
     port = settings.get('port', 5000)
     server_ready_timeout = settings.get('server_ready_timeout', 3)

--- a/pytest_mock_server.py
+++ b/pytest_mock_server.py
@@ -1,8 +1,10 @@
 import os
+import time
 import threading
-from typing import Optional, Dict, Callable, Any
+import urllib
+from typing import Any, Callable, Dict, Optional
 
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, url_for
 
 app = Flask(__name__)
 
@@ -24,6 +26,8 @@ def add_route(url: str,
     :param status_code: return status code
     :param headers: return headers
     :param callback: function will be executes before response returns
+
+    :return: Sample URL for testing
     """
     endpoint = '{url}::{method}::{status_code}'.format(
         url=url, method=method, status_code=status_code
@@ -38,11 +42,38 @@ def add_route(url: str,
             json_response.headers.update(headers)
         return json_response, status_code
 
+    with app.app_context(), app.test_request_context():
+        url = url_for(endpoint)
+
+    return url
+
 
 def start_server(**kwargs):
     thread = threading.Thread(target=app.run, daemon=True, kwargs=kwargs)
     thread.start()
-    return thread
+
+def assert_server_ready(url, **settings) -> None:
+    """
+    Assert server is ready.
+
+    :param url: server url returned by `url_for`
+    :param port: server port, default is 5000
+    """
+    port = settings.get('port', 5000)
+    server_ready_timeout = settings.get('server_ready_timeout', 3)
+
+    url = "http://localhost:{port}{url}".format(port=port, url=url)
+
+    start = time.time()
+
+    while True:
+        try:
+            urllib.request.urlopen(url)
+            break
+        except urllib.error.URLError:
+            if time.time() - start > server_ready_timeout:
+                raise TimeoutError(f"Server is not ready in {server_ready_timeout} seconds. Please check your server_settings.")
+            time.sleep(0.1)
 
 
 def pytest_configure(config):
@@ -55,6 +86,10 @@ def pytest_runtest_setup(item):
     settings = settings.kwargs if settings else {}
     if len(markers) > 0:
         os.environ['WERKZEUG_RUN_MAIN'] = 'true'
+        urls = []
         for marker in markers:
-            add_route(*marker.args, **marker.kwargs)
+            url = add_route(*marker.args, **marker.kwargs)
+            urls.append(url)
         start_server(**settings)
+        for url in urls:
+            assert_server_ready(url, **settings)


### PR DESCRIPTION
Hi, I found a more flexible way to determine whether the flask server is ready. Because I make a force push to my fork repository, the lagacy PR can't be reopened. So I create a new PR here.

1. Use flask function `url_for` to dynamic get request url.
2. In the main thread, Loop forever util it can make a request to the server successfully.
3. I expose a `server_setting`: `server_ready_timeout` to avoid dead circulation.

Solved #6 